### PR TITLE
Allow gem to be used with mongoid 5

### DIFF
--- a/mongoid-rails.gemspec
+++ b/mongoid-rails.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.summary     = "Strong parameter integration between rails and mongoid"
   s.license     = "MIT"
 
-  s.add_dependency("mongoid", ["~> 4.0"])
+  s.add_dependency("mongoid", ["~> 5.0"])
 
   s.files        = `git ls-files`.split("\n")
   s.require_path = 'lib'


### PR DESCRIPTION
I did a quick audit and it seems that the monkey patches are still compatible with [mongoid@5.1.3](https://github.com/mongodb/mongoid/tree/v5.1.3).
